### PR TITLE
Skip zeroAccSpatFrc for the constraint passes

### DIFF
--- a/src/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -936,7 +936,8 @@ void btMultiBody::computeAccelerationsArticulatedBodyAlgorithmMultiDof(btScalar 
 			if (m_useGyroTerm)
 				zeroAccSpatFrc[i + 1].addAngular(spatVel[i + 1].getAngular().cross(m_links[i].m_inertiaLocal * spatVel[i + 1].getAngular()));
 			//
-			zeroAccSpatFrc[i + 1].addLinear(m_links[i].m_mass * spatVel[i + 1].getAngular().cross(spatVel[i + 1].getLinear()));
+                        if (!isConstraintPass)
+      				zeroAccSpatFrc[i + 1].addLinear(m_links[i].m_mass * spatVel[i + 1].getAngular().cross(spatVel[i + 1].getLinear()));
 			//
 			//btVector3 temp = m_links[i].m_mass * spatVel[i+1].getAngular().cross(spatVel[i+1].getLinear());
 			////clamp parent's omega


### PR DESCRIPTION
I came to this change based purely on analysis of expected output vs actual output. I don't have good grasp as to whether this change is appropriate from a physics perspective.


With this change, gz-physics [TYPED_TEST(JointTransmittedWrenchFixture, PendulumInMotion)](https://github.com/gazebosim/gz-physics/pull/434/files#diff-828590a1c309e9b2880e999731ad1df6a517e5e78103c4ff50a971f1ab5755e8R272) will pass.